### PR TITLE
Pin version of ipywidgets in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install scipy numpy tvb-library pythreejs pyvista ipywidgets ebrains_drive mne==0.24.1
+          python -m pip install scipy numpy tvb-library pythreejs pyvista ipywidgets==7.7.1 ebrains_drive mne==0.24.1
           python -m pip install pytest pytest-cov pytest-mock tvb-data
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import setuptools
 import shutil
 from pathlib import Path
 
-REQUIRED_PACKAGES = ["colorcet", "ebrains_drive", "ipywidgets", "mne==0.24.1",
+REQUIRED_PACKAGES = ["colorcet", "ebrains_drive", "ipywidgets==7.7.1", "mne==0.24.1",
                      "pythreejs", "pyvista>=0.34.0", "tvb-library>=2.5"]
 
 REQUIRED_EXTRA_EXAMPLES = ["tvb-data"]


### PR DESCRIPTION
Tests are failed in master because of the new version of ipywidgets: 
```
ImportError while importing test module '/home/runner/work/tvb-widgets/tvb-widgets/tvbwidgets/tests/test_head_widget.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.8.13/x[64](https://github.com/the-virtual-brain/tvb-widgets/runs/7993794872?check_suite_focus=true#step:6:65)/lib/python3.8/site-packages/pyvista/jupyter/__init__.py:43: in _validate_jupyter_backend
    import pythreejs
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/pythreejs/__init__.py:8: in <module>
    from .pythreejs import *
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/pythreejs/pythreejs.py:22: in <module>
    from .core.BufferAttribute import BufferAttribute
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/pythreejs/core/BufferAttribute.py:4: in <module>
    from .BufferAttribute_autogen import BufferAttribute as BaseBufferAttribute
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/pythreejs/core/BufferAttribute_autogen.py:14: in <module>
    from ..traits import *
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/pythreejs/traits.py:20: in <module>
    from ipydatawidgets import DataUnion, NDArrayWidget, shape_constraints
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/ipydatawidgets/__init__.py:7: in <module>
    from .ndarray import *
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/ipydatawidgets/ndarray/__init__.py:7: in <module>
    from .media import DataImage
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/ipydatawidgets/ndarray/media.py:13: in <module>
    from .union import DataUnion, data_union_serialization
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/ipydatawidgets/ndarray/union.py:12: in <module>
    from .serializers import data_union_serialization
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/ipydatawidgets/ndarray/serializers.py:49: in <module>
    from ipython_genutils.py3compat import string_types
E   ModuleNotFoundError: No module named 'ipython_genutils'

During handling of the above exception, another exception occurred:
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tvbwidgets/tests/test_head_widget.py:13: in <module>
    import tvbwidgets.api as api
tvbwidgets/api.py:10: in <module>
    from .ui.head_widget import HeadWidget, HeadWidgetBase, HeadWidgetConfig
tvbwidgets/ui/head_widget.py:26: in <module>
    pyvista.set_jupyter_backend('pythreejs')
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/pyvista/jupyter/__init__.py:141: in set_jupyter_backend
    pyvista.global_theme._jupyter_backend = _validate_jupyter_backend(backend)
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/pyvista/jupyter/__init__.py:45: in _validate_jupyter_backend
    raise ImportError('Please install `pythreejs` to use this feature.')
E   ImportError: Please install `pythreejs` to use this feature.
```

I pinned the compatibleversion for now, but we should investigate and maybe support the latest version.