### PR TITLE
WID-207: synchronize the progress bar with the hpc job

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ colorcet
 ebrains_drive
 ipympl > 0.8.5
 ipywidgets == 7.7.2
-IPython
+IPython <= 8.12
 joblib
 mne >= 1.0
 numpy

--- a/tvbwidgets/core/hpc/config.py
+++ b/tvbwidgets/core/hpc/config.py
@@ -17,6 +17,7 @@ class HPCConfig(object):
     env_name: str
     n_threads: int
     resources: Resources
+    timeout = -1
 
     STORAGES = {'DAINT-CSCS': 'HOME',
                 'JUSUF': 'PROJECT',

--- a/tvbwidgets/core/hpc/launcher.py
+++ b/tvbwidgets/core/hpc/launcher.py
@@ -4,6 +4,7 @@
 #
 # (c) 2022-2023, TVB Widgets Team
 #
+import time
 
 import pyunicore.client
 from datetime import datetime
@@ -14,6 +15,7 @@ from pkg_resources import get_distribution, DistributionNotFound
 from tvbwidgets.core.auth import get_current_token
 from tvbwidgets.core.hpc.config import HPCConfig
 from tvbwidgets.core.logger.builder import get_logger
+from tvbwidgets.core.pse.parameters import PROGRESS_BAR_STATUS_FILE
 
 LOGGER = get_logger(__name__)
 
@@ -25,8 +27,8 @@ class HPCLaunch(object):
     JOB_TYPE_KEY = 'Job type'
     INTERACTIVE_KEY = 'interactive'
 
-    def __init__(self, hpc_config, param1, param2, param1_values, param2_values, metrics, file_name):
-        # type: (HPCConfig, str, str, list, list, list, str) -> None
+    def __init__(self, hpc_config, param1, param2, param1_values, param2_values, metrics, file_name, update_progress):
+        # type: (HPCConfig, str, str, list, list, list, str, Callable) -> None
         self.config = hpc_config
         self.param1 = param1
         self.param2 = param2
@@ -34,6 +36,7 @@ class HPCLaunch(object):
         self.param2_values = param2_values
         self.metrics = metrics
         self.file_name = file_name
+        self.update_progress = update_progress
         # TODO WID-208 link here the serialized simulator in the list of inputs
         self.submit_job("tvbwidgets.core.pse.parameters", [], True)
 
@@ -190,10 +193,32 @@ class HPCLaunch(object):
         else:
             LOGGER.info('You can use "PyUnicore Tasks Stream" tool to monitor it.')
 
+    @staticmethod
+    def read_file_from_hpc(job, file_name):
+        try:
+            content = job.working_dir.listdir()
+            storage_config_file = content.get(file_name)
+            if storage_config_file is None:
+                LOGGER.warning(f"Could not find file: {file_name}")
+                return 0
+            return storage_config_file.raw().read()
+        except Exception as e:
+            LOGGER.error(f"Could not read file: {file_name}", exc_info=e)
+            return 0
+
     def monitor_job(self, job):
         LOGGER.info('Waiting for job to finish...'
                     'It can also be monitored interactively with the "PyUnicore Tasks Stream" tool.')
-        job.poll()
+
+        start_time = int(time.time())
+        # we replaced job.poll to our custom while, to update the progress bar as well
+        while job.status.ordinal() < pyunicore.client.JobStatus.SUCCESSFUL.ordinal():
+            state = int(self.read_file_from_hpc(job, PROGRESS_BAR_STATUS_FILE))
+            self.update_progress(state + 1)
+            time.sleep(2)
+            if self.config.timeout > 0 and int(time.time()) > start_time + self.config.timeout:
+                raise TimeoutError("Timeout waiting for job to become %s" % state.value)
+
 
         if job.properties['status'] == Status.FAILED:
             LOGGER.error("Job finished with errors.")

--- a/tvbwidgets/core/hpc/launcher.py
+++ b/tvbwidgets/core/hpc/launcher.py
@@ -217,8 +217,9 @@ class HPCLaunch(object):
             self.update_progress(state + 1)
             time.sleep(2)
             if self.config.timeout > 0 and int(time.time()) > start_time + self.config.timeout:
-                raise TimeoutError("Timeout waiting for job to become %s" % state.value)
-
+                # signalize an error
+                self.update_progress(error_msg="Connection Timeout")
+                raise TimeoutError(f"Timeout waiting for job to become {state.value}")
 
         if job.properties['status'] == Status.FAILED:
             LOGGER.error("Job finished with errors.")

--- a/tvbwidgets/core/pse/parameters.py
+++ b/tvbwidgets/core/pse/parameters.py
@@ -15,6 +15,7 @@ A collection of parameter related classes and functions.
 import os
 import json
 import sys
+import threading
 import numpy as np
 from copy import deepcopy
 from typing import List, Any, Optional, Callable
@@ -32,6 +33,8 @@ from tvbwidgets.core.logger.builder import get_logger
 
 # Here put explicit module name string, for __name__ == __main__
 LOGGER = get_logger("tvbwidgets.core.pse.parameters")
+
+PROGRESS_BAR_STATUS_FILE = "progress_bar_status.txt"
 
 try:
     from dask.distributed import Client
@@ -218,6 +221,7 @@ class JobLibExec:
     backend: Optional[Any]
     checkpoint_dir: Optional[str]
     update_progress: Optional[Callable]
+    progress_file_lock: Optional[Any] = threading.Lock()
 
     def _checkpoint(self, result, i):
         if self.checkpoint_dir is not None:
@@ -243,8 +247,21 @@ class JobLibExec:
                 np.save(os.path.join(self.checkpoint_dir, 'param_vals.npy'), self.seq.values)
 
     def monitor_execution(self):
-        if self.update_progress is not None:
-            self.update_progress()
+        try:
+            if self.update_progress is not None:
+                self.update_progress()
+            else:
+                with self.progress_file_lock:
+                    with open(PROGRESS_BAR_STATUS_FILE, "r+") as f:
+                        # set the cursor to the beginning of the file
+                        f.seek(0)
+                        status = int(f.read())
+                        status += 1
+                        f.seek(0)
+                        f.write(str(status))
+        except Exception as e:
+            LOGGER.error("Could not update the progress bar status", exc_info=e)
+
 
     def __call__(self, n_jobs=-1):
         LOGGER.info("Simulation starts")
@@ -389,6 +406,9 @@ if __name__ == '__main__':
 
     # TODO WID-208 deserialize this instance after being passed from the remote launcher
     sim = Simulator(connectivity=Connectivity.from_file()).configure()
+
+    with open(PROGRESS_BAR_STATUS_FILE, "w+") as f:
+        f.write("0")
 
     launch_local_param(sim, param1, param2, param1_values, param2_values, metrics, file_name,
                        n_threads=n_threads)

--- a/tvbwidgets/ui/pse_launcher_widget.py
+++ b/tvbwidgets/ui/pse_launcher_widget.py
@@ -142,12 +142,16 @@ class PSELauncher(TVBWidget):
         else:
             return file_name
 
-    def update_progress(self, value=None):
+    def update_progress(self, value=None, error_msg=None):
+        if error_msg is None:
+            self._update_info_message(error_msg, is_error=True)
+
         with self.progress_lock:
             if value is None:
                 self.progress.value += 1
-            else:
+            elif value >= 0:
                 self.progress.value = value
+
 
     def create_metrics(self):
         self.metrics_sm = widgets.SelectMultiple(

--- a/tvbwidgets/ui/pse_launcher_widget.py
+++ b/tvbwidgets/ui/pse_launcher_widget.py
@@ -89,7 +89,7 @@ class PSELauncher(TVBWidget):
         file_name = self.verify_file_name()
         self.progress.min = 0
         self.progress.max = len(x_values) * len(y_values) + 1
-        self.progress.value = 1
+        self.update_progress(1)
         return file_name, x_values, y_values
 
     def handle_launch_buttons(self):
@@ -109,7 +109,7 @@ class PSELauncher(TVBWidget):
             if self.launch_hpc_button.button_style == "success":
                 file_name, x_values, y_values = self._prepare_launch("HPC")
                 HPCLaunch(self.hpc_config, self.param_1.value, self.param_2.value, x_values, y_values,
-                          list(self.metrics_sm.value), file_name)
+                          list(self.metrics_sm.value), file_name, self.update_progress)
                 self._update_info_message("PSE completed! ")
 
         def local_launch(_change):
@@ -142,9 +142,12 @@ class PSELauncher(TVBWidget):
         else:
             return file_name
 
-    def update_progress(self):
+    def update_progress(self, value=None):
         with self.progress_lock:
-            self.progress.value += 1
+            if value is None:
+                self.progress.value += 1
+            else:
+                self.progress.value = value
 
     def create_metrics(self):
         self.metrics_sm = widgets.SelectMultiple(


### PR DESCRIPTION
We tried to find a more natural way to synch status progress from HPC to a local notebook, but we could not find support in the unicore API.
Thus, we are writing in the job a HPC local file with progress count, this file is polled from the client notebook. We read the file content every few seconds and put the value in the progress bar.