### PR TITLE
Fix: default border mutation and head widget title

### DIFF
--- a/tvbwidgets/tests/test_head_widget.py
+++ b/tvbwidgets/tests/test_head_widget.py
@@ -126,3 +126,24 @@ def test_head_widget(mocker):
 
     widget.load_selected_file(Sensors, '.txt')
     assert 'Could not load' in widget.message_label.value
+
+
+def test_head_widget_title_renders_class_name(mocker):
+    mocker.patch('k3d.Plot.display', lambda self: None)
+    widget = api.HeadWidget([])
+    html_widget = widget.children[0]
+    assert 'HeadWidget' in html_widget.value
+    assert "<class" not in html_widget.value, (
+        "HeadWidget title is rendering the class object. "
+        "Use HeadWidget.__name__ in the f-string, not HeadWidget directly."
+    )
+
+
+def test_head_widget_accepts_extra_kwargs(mocker):
+    mocker.patch('k3d.Plot.display', lambda self: None)
+    try:
+        widget = api.HeadWidget([], description="test")
+    except TypeError as e:
+        raise AssertionError(
+            f"HeadWidget crashed with extra kwargs — likely *kwargs instead of **kwargs: {e}"
+        )

--- a/tvbwidgets/tests/test_spacetime_widget.py
+++ b/tvbwidgets/tests/test_spacetime_widget.py
@@ -76,8 +76,9 @@ def test_add_options(wid):
     assert wid.options.children[3].value == "None"
 
 
-
-
-    
-
-
+def test_default_border_not_mutated(wid):
+    from tvbwidgets.ui.base_widget import TVBWidget
+    assert 'min_width' not in TVBWidget.DEFAULT_BORDER, (
+        "SpaceTimeVisualizerWidget mutated the shared TVBWidget.DEFAULT_BORDER. "
+        "Use layout = {**self.DEFAULT_BORDER} instead of layout = self.DEFAULT_BORDER."
+    )

--- a/tvbwidgets/ui/head_widget.py
+++ b/tvbwidgets/ui/head_widget.py
@@ -57,8 +57,8 @@ class HeadWidget(ipywidgets.VBox, TVBWidget):
         Docs
         """
         self.output = ipywidgets.Output(layout=ipywidgets.Layout(width=str(width) + 'px', height=str(height) + 'px'))
-        super(HeadWidget, self).__init__([ipywidgets.HTML(value=f'<h1>{HeadWidget}</h1>'), self.output],
-                                         layout=self.DEFAULT_BORDER, *kwargs)
+        super(HeadWidget, self).__init__([ipywidgets.HTML(value=f'<h1>{HeadWidget.__name__}</h1>'), self.output],
+                                         layout=self.DEFAULT_BORDER, **kwargs)
         self.plot = None
         self.refresh_plot(datatypes)
 

--- a/tvbwidgets/ui/spacetime_widget.py
+++ b/tvbwidgets/ui/spacetime_widget.py
@@ -272,7 +272,7 @@ class SpaceTimeVisualizerWidget(TVBWidget):
         plt.close(self.fig)
 
     def _prepare_plot_details(self):
-        layout = self.DEFAULT_BORDER
+        layout = {**self.DEFAULT_BORDER}
         layout['min_width'] = "150px"
         self.plot_details = HTML(
             value=self._generate_details(),


### PR DESCRIPTION
# **Problem** 

1. Shared Layout Mutation: SpaceTimeVisualizerWidget directly modifies the class-level TVBWidget.DEFAULT_BORDER dictionary. This permanently injects a min_width that affects all subsequently instantiated widgets (like HeadWidget or PhasePlaneWidget) for the remainder of the kernel session.

2. HTML Title Rendering: HeadWidget incorrectly renders its raw class object in the HTML title (<class 'tvbwidgets.ui.head_widget.HeadWidget'>) instead of its class name.

3. Kwargs Unpacking Error: HeadWidget.__init__ uses *kwargs in its super() call. This unpacks dictionary keys as positional arguments, throwing a TypeError if any extra keyword arguments are passed.

# **Fix**

1. Layout: Used a shallow copy ({**self.DEFAULT_BORDER}) in SpaceTimeVisualizerWidget to prevent mutating the shared layout dictionary.
 
2. Title: Appended .__name__ to the HTML string interpolation in HeadWidget to correctly render the title as HeadWidget.
 
3. Kwargs: Replaced *kwargs with **kwargs in HeadWidget.__init__ to properly pass keyword arguments.


  ### Files changed
- `tvbwidgets/ui/spacetime_widget.py` — 1 line
- `tvbwidgets/ui/head_widget.py` — 2 characters

# **Test plan**

1. Added 1 regression test in tvbwidgets/tests/test_spacetime_widget.py to ensure layouts aren't mutated.

2. Added 2 regression tests in tvbwidgets/tests/test_head_widget.py to verify title rendering and kwarg initialization.
