### PR TITLE
Add timeouts to notebook CI runner

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -10,7 +10,9 @@ jobs:
   build:
     name: Run notebooks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
+
       fail-fast: false
 #    env:
 #      ACTIONS_RUNNER_DEBUG: true

--- a/dev/notebook_runner.py
+++ b/dev/notebook_runner.py
@@ -17,7 +17,7 @@ from nbconvert.preprocessors import ExecutePreprocessor
 def execute_notebook(in_path, notebook):
     with open(os.path.join(in_path, notebook), encoding='utf-8') as f:
         nb = nbformat.read(f, as_version=4)
-        ep = ExecutePreprocessor(timeout=None)
+        ep = ExecutePreprocessor(timeout=300)
         ep.preprocess(nb)
 
     # with open(os.path.join(out_path, notebook), 'w+', encoding='utf-8') as f: # for debug only


### PR DESCRIPTION
Fixes #104 **(partially)**

The notebook runner currently uses `ExecutePreprocessor(timeout=None)`, which causes interactive widgets (e.g. ConnectivityWidget) to hang indefinitely in headless CI. This burns 6 hours of GitHub Actions compute per failed run.

Changes:
1) `dev/notebook_runner.py`: cap each notebook at 5 minutes (`timeout=300`)
2) `.github/workflows/notebooks.yml`: cap the entire job at 30 minutes (`timeout-minutes: 30`)

This keeps CI fast and commit statuses reliable when widget rendering blocks in headless environments.